### PR TITLE
Add PAT workaround for PVs

### DIFF
--- a/Dockerfile.xen
+++ b/Dockerfile.xen
@@ -10,6 +10,10 @@ ENV XEN_VERSION=${XEN_VERSION}
 RUN git clone -b "RELEASE-$XEN_VERSION" https://github.com/xen-project/xen.git && cd xen
 WORKDIR /usr/src/xen
 
+# patch xen
+COPY ./patches-xen ./patches-xen
+RUN for patch in patches-xen/*.patch; do patch -p1 < $patch; done
+
 # get rid of -Werror
 RUN find . \( -name '*.mk' -o -name 'Make*' \) -exec sed -i -e 's/-Werror//g' {} +
 

--- a/patches-xen/x86-Use-Linux-s-PAT.patch
+++ b/patches-xen/x86-Use-Linux-s-PAT.patch
@@ -1,0 +1,79 @@
+From 7f3f94f443f652e4a59c111d4cf8b5fb3b771612 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Sun, 4 Dec 2022 07:57:44 -0500
+Subject: [PATCH] x86: Use Linux's PAT
+
+Use the same PAT setting as Linux to workaround buggy drivers that have
+hardcoded assumptions about it.
+---
+ xen/arch/x86/include/asm/page.h      |  4 ++--
+ xen/arch/x86/include/asm/processor.h | 11 ++++++-----
+ xen/arch/x86/mm.c                    |  7 -------
+ 3 files changed, 8 insertions(+), 14 deletions(-)
+
+diff --git a/xen/arch/x86/include/asm/page.h b/xen/arch/x86/include/asm/page.h
+index 350d1fb110..2624cc6bda 100644
+--- a/xen/arch/x86/include/asm/page.h
++++ b/xen/arch/x86/include/asm/page.h
+@@ -333,11 +333,11 @@ void efi_update_l4_pgtable(unsigned int l4idx, l4_pgentry_t l4e);
+ 
+ /* Memory types, encoded under Xen's choice of MSR_PAT. */
+ #define _PAGE_WB         (                                0)
+-#define _PAGE_WT         (                        _PAGE_PWT)
++#define _PAGE_WC         (                        _PAGE_PWT)
+ #define _PAGE_UCM        (            _PAGE_PCD            )
+ #define _PAGE_UC         (            _PAGE_PCD | _PAGE_PWT)
+-#define _PAGE_WC         (_PAGE_PAT                        )
+ #define _PAGE_WP         (_PAGE_PAT |             _PAGE_PWT)
++#define _PAGE_WT         (_PAGE_PAT | _PAGE_PCD | _PAGE_PWT)
+ 
+ /*
+  * Debug option: Ensure that granted mappings are not implicitly unmapped.
+diff --git a/xen/arch/x86/include/asm/processor.h b/xen/arch/x86/include/asm/processor.h
+index c26ef9090c..dc31eb7a68 100644
+--- a/xen/arch/x86/include/asm/processor.h
++++ b/xen/arch/x86/include/asm/processor.h
+@@ -65,16 +65,17 @@
+ 
+ /*
+  * Host IA32_CR_PAT value to cover all memory types.  This is not the default
+- * MSR_PAT value, and is an ABI with PV guests.
++ * MSR_PAT value, and is and is the same one used by Linux.  The proprietary
++ * Nvidia driver (and possibly other kernel code) requires this value.
+  */
+ #define XEN_MSR_PAT ((_AC(X86_MT_WB,  ULL) << 0x00) | \
+-                     (_AC(X86_MT_WT,  ULL) << 0x08) | \
++                     (_AC(X86_MT_WC,  ULL) << 0x08) | \
+                      (_AC(X86_MT_UCM, ULL) << 0x10) | \
+                      (_AC(X86_MT_UC,  ULL) << 0x18) | \
+-                     (_AC(X86_MT_WC,  ULL) << 0x20) | \
++                     (_AC(X86_MT_WB,  ULL) << 0x20) | \
+                      (_AC(X86_MT_WP,  ULL) << 0x28) | \
+-                     (_AC(X86_MT_UC,  ULL) << 0x30) | \
+-                     (_AC(X86_MT_UC,  ULL) << 0x38))
++                     (_AC(X86_MT_UCM, ULL) << 0x30) | \
++                     (_AC(X86_MT_WT,  ULL) << 0x38))
+ 
+ #ifndef __ASSEMBLY__
+ 
+diff --git a/xen/arch/x86/mm.c b/xen/arch/x86/mm.c
+index c3e15a029b..509a73b299 100644
+--- a/xen/arch/x86/mm.c
++++ b/xen/arch/x86/mm.c
+@@ -6373,13 +6373,6 @@ unsigned long get_upper_mfn_bound(void)
+ 
+ static void __init __maybe_unused build_assertions(void)
+ {
+-    /*
+-     * If this trips, any guests that blindly rely on the public API in xen.h
+-     * (instead of reading the PAT from Xen, as Linux 3.19+ does) will be
+-     * broken.  Furthermore, live migration of PV guests between Xen versions
+-     * using different PATs will not work.
+-     */
+-    BUILD_BUG_ON(XEN_MSR_PAT != 0x050100070406ULL);
+ }
+ 
+ /*
+-- 
+2.50.1
+


### PR DESCRIPTION
Sourced from: https://github.com/QubesOS/qubes-vmm-xen/blob/b4365d5401516a8fc5d91104c3fcd6081ed025d5/1018-x86-Use-Linux-s-PAT.patch

This  quells the `nvidia` driver ([open](https://github.com/NVIDIA/open-gpu-kernel-modules)) complaining about PAT support:

```
 [   97.369788] NVRM: PAT configuration unsupported.
```

It is, as per original author, a dirty hack for driver bugs, but at-least the nvidia driver needs it ATM.