### PR TITLE
Allow Xen hypervisor to be built from git topic branches and snapshots

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,7 @@ jobs:
         file: ./Dockerfile.${{ matrix.component }}
         platforms: linux/amd64,linux/aarch64
         tags: ghcr.io/edera-dev/${{ matrix.component }}:nightly
+        build-args: XEN_BRANCH=wip/vpci-pvh
         push: true
     - name: Sign the image
       env:

--- a/Dockerfile.xen
+++ b/Dockerfile.xen
@@ -1,5 +1,7 @@
 FROM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS build
 ARG XEN_VERSION=4.19.1
+ARG XEN_BRANCH=RELEASE-$XEN_VERSION
+ARG XEN_REPO=https://github.com/edera-dev/xen.git
 WORKDIR /usr/src
 
 # build dependencies
@@ -7,7 +9,9 @@ RUN apk update && apk add build-base git flex bison python3 gnu-efi
 
 # check out xen sources
 ENV XEN_VERSION=${XEN_VERSION}
-RUN git clone -b "RELEASE-$XEN_VERSION" https://github.com/xen-project/xen.git && cd xen
+ENV XEN_BRANCH=${XEN_BRANCH}
+ENV XEN_REPO=${XEN_REPO}
+RUN git clone -b "$XEN_BRANCH" $XEN_REPO && cd xen
 WORKDIR /usr/src/xen
 
 # get rid of -Werror


### PR DESCRIPTION
Also while here, move nightly hypervisor builds to `wip/vpci-pvh`.

cc @tycho @azenla @kdaula