### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,8 @@ jobs:
         file: ./Dockerfile.${{ matrix.component }}
         platforms: linux/amd64,linux/aarch64
         tags: ghcr.io/edera-dev/${{ matrix.component }}:nightly
-        build-args: XEN_BRANCH=edera/4.21
+        build-args:
+          - XEN_VERSION=4.21
         push: true
     - name: Sign the image
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,8 @@ jobs:
         file: ./Dockerfile.${{ matrix.component }}
         platforms: linux/amd64,linux/aarch64
         tags: ghcr.io/edera-dev/${{ matrix.component }}:${{ matrix.release }}
-        build-args: XEN_VERSION=${{ matrix.release }}
+        build-args:
+          - XEN_VERSION=${{ matrix.release }}
         push: true
     - name: Sign the image
       env:

--- a/Dockerfile.xen
+++ b/Dockerfile.xen
@@ -1,7 +1,7 @@
 FROM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS build
 ARG XEN_VERSION=4.19.1
-ARG XEN_BRANCH=RELEASE-$XEN_VERSION
 ARG XEN_REPO=https://github.com/edera-dev/xen.git
+ARG XEN_BRANCH=edera/$XEN_VERSION
 WORKDIR /usr/src
 
 # build dependencies


### PR DESCRIPTION
See https://github.com/edera-dev/xen-oci/actions/runs/18145348983/job/51645685438

This is because actions are variously overriding XEN_BRANCH or XEN_VERSION, but really the latter is the only thing we need to set/override.