### PR TITLE
oxenstored lacked WORKDIR

### DIFF
--- a/Dockerfile.oxenstored
+++ b/Dockerfile.oxenstored
@@ -15,7 +15,9 @@ COPY ./patches ./patches
 ENV XEN_VERSION=${XEN_VERSION}
 ENV XEN_BRANCH=${XEN_BRANCH}
 ENV XEN_REPO=${XEN_REPO}
-RUN git clone -b "$XEN_BRANCH" $XEN_REPO && cd xen
+RUN git clone -b "$XEN_BRANCH" $XEN_REPO
+
+WORKDIR /usr/src/xen
 
 # patch build system
 RUN sh /usr/src/apply-patches.sh ${XEN_VERSION} oxenstored

--- a/Dockerfile.qemu-xen
+++ b/Dockerfile.qemu-xen
@@ -13,7 +13,7 @@ RUN apk update && apk add build-base git flex bison perl bash coreutils argp-sta
 ENV XEN_VERSION=${XEN_VERSION}
 ENV XEN_BRANCH=${XEN_BRANCH}
 ENV XEN_REPO=${XEN_REPO}
-RUN git clone -b "$XEN_BRANCH" $XEN_REPO && cd xen
+RUN git clone -b "$XEN_BRANCH" $XEN_REPO
 
 WORKDIR /usr/src/xen
 

--- a/Dockerfile.xen
+++ b/Dockerfile.xen
@@ -11,7 +11,8 @@ RUN apk update && apk add build-base git flex bison python3 gnu-efi
 ENV XEN_VERSION=${XEN_VERSION}
 ENV XEN_BRANCH=${XEN_BRANCH}
 ENV XEN_REPO=${XEN_REPO}
-RUN git clone -b "$XEN_BRANCH" $XEN_REPO && cd xen
+RUN git clone -b "$XEN_BRANCH" $XEN_REPO
+
 WORKDIR /usr/src/xen
 
 # get rid of -Werror


### PR DESCRIPTION
The `oxenstored` containerfile lacked WORKDIR and so was trying to `configure` in the wrong location.

see https://github.com/edera-dev/xen-oci/actions/runs/18147386000