### PR TITLE
fix: carry patches over to 4.21

### DIFF
--- a/patches/4.21/qemu/hackfix-cleanup-fsdev-on-9pfs-free.patch
+++ b/patches/4.21/qemu/hackfix-cleanup-fsdev-on-9pfs-free.patch
@@ -1,0 +1,19 @@
+diff --git a/hw/9pfs/xen-9p-backend.c b/hw/9pfs/xen-9p-backend.c
+index 79359d911a..ae1ac3a566 100644
+--- a/hw/9pfs/xen-9p-backend.c
++++ b/hw/9pfs/xen-9p-backend.c
+@@ -382,6 +382,14 @@ static void xen_9pfs_disconnect(struct XenLegacyDevice *xendev)
+ 
+ static int xen_9pfs_free(struct XenLegacyDevice *xendev)
+ {
++    // XXX: this is a hackfix that allows us to close the fsdev's rootfd
++    // the rootfd is closed in the cleanup function...
++    Xen9pfsDev *xen_9pdev = container_of(xendev, Xen9pfsDev, xendev);
++    V9fsState *s = &xen_9pdev->state;
++
++    if (s->ops->cleanup != NULL)
++        s->ops->cleanup(&s->ctx);
++
+     trace_xen_9pfs_free(xendev->name);
+ 
+     return 0;

--- a/patches/4.21/qemu/series
+++ b/patches/4.21/qemu/series
@@ -1,0 +1,1 @@
+hackfix-cleanup-fsdev-on-9pfs-free.patch


### PR DESCRIPTION
Looks like we may have missed the patches when we upgraded to 4.21. Missing the qemu patches caused this fix to regress https://github.com/edera-dev/protect/issues/904.

I remember we had an issue with oxenstored in the v1.4.0 release - could this also be the reason? Do we want to carry the oxenstored patches over as well?