### PR TITLE
feature(qemu-xen): use libucontext for qemu coroutines

### DIFF
--- a/Dockerfile.qemu-xen
+++ b/Dockerfile.qemu-xen
@@ -1,5 +1,5 @@
 FROM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS build
-ARG XEN_VERSION=4.19.1
+ARG XEN_VERSION=4.21
 ARG XEN_BRANCH=edera/$XEN_VERSION
 ARG XEN_REPO=https://github.com/edera-dev/xen.git
 WORKDIR /usr/src
@@ -32,6 +32,15 @@ RUN CFLAGS="-O2 -Wall -static -DUSE_PTHREAD" make -j$(nproc) -C tools/libs/evtch
 RUN CFLAGS="-O2 -Wall -static -DUSE_PTHREAD" make -j$(nproc) -C tools/libs/toolcore all V=1 nosharedlibs=y
 RUN CFLAGS="-O2 -Wall -static -DUSE_PTHREAD" make -j$(nproc) -C tools/libs/toollog all V=1 nosharedlibs=y
 RUN CFLAGS="-O2 -Wall -static -DUSE_PTHREAD" make -j$(nproc) -C tools/libs/store all V=1 nosharedlibs=y
+
+# build libucontext
+ARG LIBUCONTEXT_VERSION=1.5
+ENV LIBUCONTEXT_VERSION=${LIBUCONTEXT_VERSION}
+WORKDIR /usr/src
+RUN git clone -b "libucontext-$LIBUCONTEXT_VERSION" https://github.com/kaniini/libucontext.git libucontext
+
+WORKDIR /usr/src/libucontext
+RUN make libucontext.a
 
 WORKDIR /usr/src
 RUN git clone -b edera https://github.com/edera-dev/qemu.git qemu-xen

--- a/build-qemu.sh
+++ b/build-qemu.sh
@@ -6,7 +6,9 @@ echo "Building for: $target"
 env PKG_CONFIG_PATH="/usr/src/xen/tools/pkg-config:/usr/lib/pkg-config:/usr/share/pkg-config" \
 ./configure --prefix=/opt/edera/qemu-xen --enable-xen --target-list=${target}-softmmu \
   --extra-cflags="-I/usr/src/xen/tools/include -I/usr/src/xen/tools/libxc -I/usr/src/xen/tools/xenstore" \
-  --extra-ldflags="-L/usr/src/xen/tools/libs/call -L/usr/src/xen/tools/libs/store -L/usr/src/xen/tools/libs/toollog -lxencall -lxenstore -lxentoollog"
+  --extra-ldflags="-L/usr/src/xen/tools/libs/call -L/usr/src/xen/tools/libs/store -L/usr/src/xen/tools/libs/toollog -lxencall -lxenstore -lxentoollog /usr/src/libucontext/libucontext.a" \
+  --with-coroutine=ucontext \
+  --enable-coroutine-pool
 make -j$(nproc)
 make install DESTDIR="/usr/src/qemu-xen/output"
 


### PR DESCRIPTION
We were bottlenecked by the sigaltstack coroutine backend.  We must go faster.

Enter [libucontext](https://github.com/kaniini/libucontext).  Deployed on two planets, this library implements userspace context switching as fast as possible.

### I/O throughput serving 9p from tmpfs

Before: 108MB/sec at 100% contention of a single CPU core (most of which was in signal handling)
After: 8531MB/sec at 100% contention of a single CPU core