### PR TITLE
build: sccache compile caching + no-publish pr/push build checks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Org-defined GitHub-hosted larger runner; not in actionlint's builtin
+  # label list.
+  labels:
+    - edera-large

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,24 @@ jobs:
         submodules: recursive
     - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
     - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+    - name: allow unprivileged user namespaces
+      # Ubuntu 24.04 runner images restrict unprivileged user namespace
+      # creation via AppArmor; rootless buildkitd requires it.
+      run: |
+        if [ "$(sudo sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null)" = "1" ]; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
     - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      # Rootless buildkit: RUN steps execute as an unprivileged user inside a
+      # user namespace (still uid 0 in-image, so artifact ownership does not
+      # change). Among other things this makes /dev/null a host bind mount
+      # the build cannot delete or replace - a build once smuggled an ELF
+      # object into /dev/null and poisoned every compiler probe that read it
+      # afterwards. (Bump the image pin manually: dependabot does not track
+      # driver-opts images.)
+      with:
+        driver-opts: image=moby/buildkit:v0.31.1-rootless@sha256:946cf909534b789c9b84af75e6d4f8cb23c3b9cb387daec5ba0f4878a3e4647c
+        buildkitd-flags: --oci-worker-no-process-sandbox
     - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
       with:
         registry: ghcr.io

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,13 +32,26 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: configure sccache
+      id: sccache
+      uses: edera-dev/actions/configure-azure-sccache@f92635e9fe8739c2b8a78fa87e9c8567bfa81b9c # v0.0.15
+      with:
+        connection-string-rw: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
+        connection-string-ro: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING_RO }}
+        key-prefix: xen
     - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       id: push-step
+      env:
+        SCCACHE_AZURE_CONNECTION_STRING: ${{ steps.sccache.outputs.connection-string }}
       with:
         file: ./Dockerfile.${{ matrix.component }}
         platforms: linux/amd64,linux/aarch64
         tags: ghcr.io/edera-dev/${{ matrix.component }}:nightly
-        build-args: XEN_VERSION=4.21
+        build-args: |
+          XEN_VERSION=4.21
+          SCCACHE_AZURE_RW_MODE=${{ steps.sccache.outputs.rw-mode }}
+        secret-envs: |
+          sccache_conn=SCCACHE_AZURE_CONNECTION_STRING
         push: true
     - name: Sign the image
       env:
@@ -49,12 +62,20 @@ jobs:
 
     - name: Build `build` stage for SBOM scan
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      env:
+        SCCACHE_AZURE_CONNECTION_STRING: ${{ steps.sccache.outputs.connection-string }}
       with:
         file: ./Dockerfile.${{ matrix.component }}
         target: build
         # single platform to only read source/commit metadata once, still sbom's all arches
         platforms: linux/amd64
-        build-args: XEN_VERSION=4.21
+        # build-args must match the main build exactly, or the ARG mismatch
+        # busts the layer cache and this rebuilds the world.
+        build-args: |
+          XEN_VERSION=4.21
+          SCCACHE_AZURE_RW_MODE=${{ steps.sccache.outputs.rw-mode }}
+        secret-envs: |
+          sccache_conn=SCCACHE_AZURE_CONNECTION_STRING
         load: true
         tags: sbom-scan-${{ matrix.component }}:latest
     - uses: anchore/sbom-action/download-syft@36a5fde73e0fcb1d1e70be9ad66b4724e783bda7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
         - qemu-xen
     name: oci build ${{ matrix.component }}
     steps:
-    - uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+    - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
       with:
         egress-policy: audit
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,11 +21,9 @@ jobs:
         - 4.21
         component:
         - xen
-        - oxenstored
-        - qemu-xen
     name: oci build ${{ matrix.component }}-${{ matrix.release }}
     steps:
-    - uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+    - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
       with:
         egress-policy: audit
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,24 @@ jobs:
         submodules: recursive
     - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
     - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+    - name: allow unprivileged user namespaces
+      # Ubuntu 24.04 runner images restrict unprivileged user namespace
+      # creation via AppArmor; rootless buildkitd requires it.
+      run: |
+        if [ "$(sudo sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null)" = "1" ]; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
     - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      # Rootless buildkit: RUN steps execute as an unprivileged user inside a
+      # user namespace (still uid 0 in-image, so artifact ownership does not
+      # change). Among other things this makes /dev/null a host bind mount
+      # the build cannot delete or replace - a build once smuggled an ELF
+      # object into /dev/null and poisoned every compiler probe that read it
+      # afterwards. (Bump the image pin manually: dependabot does not track
+      # driver-opts images.)
+      with:
+        driver-opts: image=moby/buildkit:v0.31.1-rootless@sha256:946cf909534b789c9b84af75e6d4f8cb23c3b9cb387daec5ba0f4878a3e4647c
+        buildkitd-flags: --oci-worker-no-process-sandbox
     - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
       with:
         registry: ghcr.io
@@ -49,9 +66,9 @@ jobs:
         MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
 
         if [ "$(printf '%s\n' "4.20" "$MAJOR_MINOR" | sort -V | head -n1)" = "$MAJOR_MINOR" ] && [ "$MAJOR_MINOR" != "4.21" ]; then
-          echo "name=RELEASE-${VERSION}" >> $GITHUB_OUTPUT
+          echo "name=RELEASE-${VERSION}" >> "$GITHUB_OUTPUT"
         else
-          echo "name=edera/${VERSION}" >> $GITHUB_OUTPUT
+          echo "name=edera/${VERSION}" >> "$GITHUB_OUTPUT"
         fi
 
     - name: configure sccache

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,8 +54,17 @@ jobs:
           echo "name=edera/${VERSION}" >> $GITHUB_OUTPUT
         fi
 
+    - name: configure sccache
+      id: sccache
+      uses: edera-dev/actions/configure-azure-sccache@f92635e9fe8739c2b8a78fa87e9c8567bfa81b9c # v0.0.15
+      with:
+        connection-string-rw: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
+        connection-string-ro: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING_RO }}
+        key-prefix: xen
     - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       id: push-step
+      env:
+        SCCACHE_AZURE_CONNECTION_STRING: ${{ steps.sccache.outputs.connection-string }}
       with:
         file: ./Dockerfile.${{ matrix.component }}
         platforms: linux/amd64,linux/aarch64
@@ -63,6 +72,9 @@ jobs:
         build-args: |
           XEN_VERSION=${{ matrix.release }}
           XEN_BRANCH=${{ steps.branch.outputs.name }}
+          SCCACHE_AZURE_RW_MODE=${{ steps.sccache.outputs.rw-mode }}
+        secret-envs: |
+          sccache_conn=SCCACHE_AZURE_CONNECTION_STRING
         push: true
     - name: Sign the image
       env:
@@ -73,13 +85,20 @@ jobs:
 
     - name: Build `build` stage for SBOM scan
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      env:
+        SCCACHE_AZURE_CONNECTION_STRING: ${{ steps.sccache.outputs.connection-string }}
       with:
         file: ./Dockerfile.${{ matrix.component }}
         target: build
         platforms: linux/amd64
+        # build-args must match the main build exactly, or the ARG mismatch
+        # busts the layer cache and this rebuilds the world.
         build-args: |
           XEN_VERSION=${{ matrix.release }}
           XEN_BRANCH=${{ steps.branch.outputs.name }}
+          SCCACHE_AZURE_RW_MODE=${{ steps.sccache.outputs.rw-mode }}
+        secret-envs: |
+          sccache_conn=SCCACHE_AZURE_CONNECTION_STRING
         load: true
         tags: sbom-scan-${{ matrix.component }}:latest
     - uses: anchore/sbom-action/download-syft@36a5fde73e0fcb1d1e70be9ad66b4724e783bda7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,24 @@ jobs:
       with:
         submodules: recursive
     - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+    - name: allow unprivileged user namespaces
+      # Ubuntu 24.04 runner images restrict unprivileged user namespace
+      # creation via AppArmor; rootless buildkitd requires it.
+      run: |
+        if [ "$(sudo sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null)" = "1" ]; then
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        fi
     - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      # Rootless buildkit: RUN steps execute as an unprivileged user inside a
+      # user namespace (still uid 0 in-image, so artifact ownership does not
+      # change). Among other things this makes /dev/null a host bind mount
+      # the build cannot delete or replace - a build once smuggled an ELF
+      # object into /dev/null and poisoned every compiler probe that read it
+      # afterwards. (Bump the image pin manually: dependabot does not track
+      # driver-opts images.)
+      with:
+        driver-opts: image=moby/buildkit:v0.31.1-rootless@sha256:946cf909534b789c9b84af75e6d4f8cb23c3b9cb387daec5ba0f4878a3e4647c
+        buildkitd-flags: --oci-worker-no-process-sandbox
     - name: configure sccache
       id: sccache
       uses: edera-dev/actions/configure-azure-sccache@f92635e9fe8739c2b8a78fa87e9c8567bfa81b9c # v0.0.15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: test
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    # Build exactly what nightly builds - both platforms, including the
+    # QEMU-emulated aarch64 half - but publish nothing. The result stays in
+    # the ephemeral buildkit cache; the check is that it builds, and the
+    # sccache stats in the log show the compile-cache health for the run's
+    # trust level (read-only for PRs, read-write on main, local-only for
+    # fork PRs without secrets).
+    runs-on: ubuntu-latest
+    name: oci build xen (no publish)
+    steps:
+    - uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        submodules: recursive
+    - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+    - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+    - name: configure sccache
+      id: sccache
+      uses: edera-dev/actions/configure-azure-sccache@f92635e9fe8739c2b8a78fa87e9c8567bfa81b9c # v0.0.15
+      with:
+        connection-string-rw: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
+        connection-string-ro: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING_RO }}
+        key-prefix: xen
+    - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      env:
+        SCCACHE_AZURE_CONNECTION_STRING: ${{ steps.sccache.outputs.connection-string }}
+      with:
+        file: ./Dockerfile.xen
+        platforms: linux/amd64,linux/aarch64
+        build-args: |
+          XEN_VERSION=4.21
+          SCCACHE_AZURE_RW_MODE=${{ steps.sccache.outputs.rw-mode }}
+        secret-envs: |
+          sccache_conn=SCCACHE_AZURE_CONNECTION_STRING
+        push: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     name: oci build xen (no publish)
     steps:
-    - uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
+    - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
       with:
         egress-policy: audit
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/Dockerfile.xen
+++ b/Dockerfile.xen
@@ -55,9 +55,15 @@ RUN find . \( -name '*.mk' -o -name 'Make*' \) -exec sed -i -e 's/-Werror//g' {}
 
 # build Xen hypervisor
 ENV CFLAGS=-Wno-error
-RUN ./configure --prefix=/usr --enable-xen --disable-tools --disable-stubdom --disable-docs
+# Every step that invokes the compiler wrappers implicitly starts the
+# sccache background server, and under rootless buildkit RUN steps have no
+# pid namespace (--oci-worker-no-process-sandbox), so a lingering daemon
+# keeps the step's container alive until the server's idle timeout - stop
+# it explicitly instead.
+RUN ./configure --prefix=/usr --enable-xen --disable-tools --disable-stubdom --disable-docs && \
+    sccache --stop-server >/dev/null 2>&1 || true
 COPY configs/xen-${TARGETARCH}.config ./xen/.config
-RUN make -C xen olddefconfig
+RUN make -C xen olddefconfig && sccache --stop-server >/dev/null 2>&1 || true
 # Fail loudly if olddefconfig silently dropped a feature we require (e.g.
 # MEM_SHARING needs CONFIG_UNSUPPORTED=y to be settable). Without this, a
 # missing feature only surfaces as a confusing runtime -EOPNOTSUPP.
@@ -69,8 +75,8 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 # an empty connection string fails sccache server startup rather than
 # falling back to the local cache.
 RUN --mount=type=secret,id=sccache_conn,env=SCCACHE_AZURE_CONNECTION_STRING \
-    sh -ec '[ -n "${SCCACHE_AZURE_CONNECTION_STRING:-}" ] || unset SCCACHE_AZURE_CONNECTION_STRING SCCACHE_AZURE_BLOB_CONTAINER; make -j"$(nproc)" xen; sccache --show-stats || true'
-RUN make install-xen
+    sh -ec '[ -n "${SCCACHE_AZURE_CONNECTION_STRING:-}" ] || unset SCCACHE_AZURE_CONNECTION_STRING SCCACHE_AZURE_BLOB_CONTAINER; make -j"$(nproc)" xen; sccache --show-stats || true; sccache --stop-server >/dev/null 2>&1 || true'
+RUN make install-xen && sccache --stop-server >/dev/null 2>&1 || true
 RUN mkdir /xenboot; ([ -f /boot/xen ] && cp /boot/xen /xenboot/xen) || \
   ([ -f /boot/xen.gz ] && cp /boot/xen.gz /xenboot/xen.gz)
 

--- a/Dockerfile.xen
+++ b/Dockerfile.xen
@@ -46,7 +46,15 @@ ARG SCCACHE_AZURE_RW_MODE=READ_WRITE
 ENV XEN_VERSION=${XEN_VERSION}
 ENV XEN_BRANCH=${XEN_BRANCH}
 ENV XEN_REPO=${XEN_REPO}
-RUN git clone -b "$XEN_BRANCH" $XEN_REPO
+# git's multi-threaded index-pack races against qemu-user's guest-memory
+# handling ("fatal: cannot pread pack file: Bad address", an intermittent
+# EFAULT), so single-thread it - but only when this stage actually runs
+# under emulation; native builds keep the parallel fast path.
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+RUN GIT_PACK_THREADS=""; \
+    [ "$TARGETPLATFORM" = "$BUILDPLATFORM" ] || GIT_PACK_THREADS="-c pack.threads=1"; \
+    git $GIT_PACK_THREADS clone -b "$XEN_BRANCH" $XEN_REPO
 
 WORKDIR /usr/src/xen
 

--- a/Dockerfile.xen
+++ b/Dockerfile.xen
@@ -1,3 +1,6 @@
+# check=skip=SecretsUsedInArgOrEnv
+# (false positive: SCCACHE_AZURE_KEY_PREFIX is a cache namespace, not a key,
+# but sccache dictates the env name and the checker pattern-matches on "KEY")
 FROM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c AS build
 ARG XEN_VERSION=4.21
 ARG XEN_REPO=https://github.com/edera-dev/xen.git
@@ -7,6 +10,37 @@ WORKDIR /usr/src
 
 # build dependencies
 RUN apk update && apk add build-base git flex bison python3 gnu-efi
+
+# Shared Azure-backed compile cache (see edera-dev/actions/configure-azure-sccache).
+# The wrappers must reference the real compiler by absolute path:
+# /usr/lib/sccache is first in PATH, so a bare compiler name would resolve
+# back to the wrapper itself and recurse.
+ARG SCCACHE_VERSION=0.16.0
+ARG SCCACHE_SHA256_AMD64=aec995a83ad3dff3d14b6314e08858b7b73d35ca85a5bcf3d3a9ec07dee35588
+ARG SCCACHE_SHA256_ARM64=f73a5c39f96bb6ebb89cc7915cf182260d4cbf30765322c5e793d0fe8bd80784
+RUN case "${TARGETARCH}" in \
+      amd64) SCCACHE_ARCH=x86_64 SCCACHE_SHA256="${SCCACHE_SHA256_AMD64}" ;; \
+      arm64) SCCACHE_ARCH=aarch64 SCCACHE_SHA256="${SCCACHE_SHA256_ARM64}" ;; \
+      *) echo "unsupported TARGETARCH ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    SCCACHE_DIST="sccache-v${SCCACHE_VERSION}-${SCCACHE_ARCH}-unknown-linux-musl" && \
+    wget -q -O /tmp/sccache.tar.gz "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_DIST}.tar.gz" && \
+    echo "${SCCACHE_SHA256}  /tmp/sccache.tar.gz" | sha256sum -c - && \
+    tar -xz -C /tmp -f /tmp/sccache.tar.gz && \
+    install -m 0755 "/tmp/${SCCACHE_DIST}/sccache" /usr/local/bin/sccache && \
+    rm -rf /tmp/sccache.tar.gz "/tmp/${SCCACHE_DIST}" && \
+    mkdir -p /usr/lib/sccache && \
+    for compiler in cc c++ gcc g++; do \
+      [ -x "/usr/bin/${compiler}" ] || continue; \
+      printf '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/%s "$@"\n' "${compiler}" >"/usr/lib/sccache/${compiler}"; \
+      chmod 0755 "/usr/lib/sccache/${compiler}"; \
+    done
+ENV PATH="/usr/lib/sccache:${PATH}"
+# Non-secret cache config; the connection string arrives only through a
+# BuildKit secret mount on the compile step and never persists in the image.
+ARG SCCACHE_AZURE_BLOB_CONTAINER=sccache
+ARG SCCACHE_AZURE_KEY_PREFIX=xen
+ARG SCCACHE_AZURE_RW_MODE=READ_WRITE
 
 # check out xen sources
 ENV XEN_VERSION=${XEN_VERSION}
@@ -31,7 +65,11 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       grep -qx 'CONFIG_MEM_SHARING=y' xen/.config || \
       (echo "ERROR: CONFIG_MEM_SHARING was dropped by olddefconfig (check CONFIG_UNSUPPORTED)" && exit 1); \
       fi
-RUN make -j$(nproc) xen
+# Without credentials (e.g. local builds), drop the Azure config entirely:
+# an empty connection string fails sccache server startup rather than
+# falling back to the local cache.
+RUN --mount=type=secret,id=sccache_conn,env=SCCACHE_AZURE_CONNECTION_STRING \
+    sh -ec '[ -n "${SCCACHE_AZURE_CONNECTION_STRING:-}" ] || unset SCCACHE_AZURE_CONNECTION_STRING SCCACHE_AZURE_BLOB_CONTAINER; make -j"$(nproc)" xen; sccache --show-stats || true'
 RUN make install-xen
 RUN mkdir /xenboot; ([ -f /boot/xen ] && cp /boot/xen /xenboot/xen) || \
   ([ -f /boot/xen.gz ] && cp /boot/xen.gz /xenboot/xen.gz)


### PR DESCRIPTION
Xen hypervisor builds now use the shared Azure-backed sccache cache that linux-kernel-oci already uses, and the repo gains a no-publish build check so changes are exercised before the weekly publishing runs.

Every nightly and release build compiles Xen from scratch on a fresh runner, and the aarch64 half runs under QEMU user emulation, where compilation is several times slower than native. The build stage of Dockerfile.xen now carries a pinned, checksum-verified sccache with compiler wrappers, and the compile step receives the cache credential through a BuildKit secret mount, so it never persists in image history or layer cache. The nightly and release workflows select credentials via the shared edera-dev/actions/configure-azure-sccache action: maintainer-gated triggers get the read-write token, everything else fails closed to read-only, and builds with no credentials at all (e.g. local ones) drop the Azure config and fall back to a local cache. Cache objects live under the `xen/` prefix in the same storage account as the kernel builds, garbage-collected by the storage-side 30-day last-access lifecycle rule.

Validated end to end against the live cache: a from-scratch rebuild of Dockerfile.xen hit 99.7% (make step ~6 minutes down to ~18 seconds), with zero read or write errors. The emulated aarch64 builds benefit the most, since every cache hit skips the emulated compiler entirely. The `sccache --show-stats` output printed at the end of each compile makes cache health visible in every build log.

The new test workflow runs on pull requests and pushes to main, building exactly what nightly builds (both platforms) but publishing nothing. Until now the only thing exercising a change was the next scheduled publish; this also means every trust level of the cache gets exercised routinely - PRs read-only, main read-write, fork PRs credential-less - including on this very PR, whose checks should show warm cache hits.