### PR TITLE
feat: enable the KVM pvclock timesource

### DIFF
--- a/Dockerfile.xen
+++ b/Dockerfile.xen
@@ -127,10 +127,14 @@ COPY configs/xen-${TARGETARCH}.config ./xen/.config
 RUN sh -ec 'make -C xen olddefconfig; sccache --stop-server >/dev/null 2>&1 || true'
 # Fail loudly if olddefconfig silently dropped a feature we require (e.g.
 # MEM_SHARING needs CONFIG_UNSUPPORTED=y to be settable). Without this, a
-# missing feature only surfaces as a confusing runtime -EOPNOTSUPP.
+# missing feature only surfaces as a confusing runtime -EOPNOTSUPP, or -- for
+# KVM_GUEST -- as nothing at all: Xen would simply keep calibrating against an
+# emulated timer and nobody would know the driver had been dropped.
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
       grep -qx 'CONFIG_MEM_SHARING=y' xen/.config || \
       (echo "ERROR: CONFIG_MEM_SHARING was dropped by olddefconfig (check CONFIG_UNSUPPORTED)" && exit 1); \
+      grep -qx 'CONFIG_KVM_GUEST=y' xen/.config || \
+      (echo "ERROR: CONFIG_KVM_GUEST was dropped by olddefconfig (needs a Xen with the KVM pvclock timesource)" && exit 1); \
       fi
 # Without credentials (e.g. local builds), drop the Azure config entirely:
 # an empty connection string fails sccache server startup rather than

--- a/configs/xen-amd64.config
+++ b/configs/xen-amd64.config
@@ -43,6 +43,7 @@ CONFIG_PVH_GUEST=y
 CONFIG_PV_SHIM=y
 # CONFIG_PV_SHIM_EXCLUSIVE is not set
 CONFIG_HYPERV_GUEST=y
+CONFIG_KVM_GUEST=y
 # CONFIG_REQUIRE_NX is not set
 # end of Architecture Features
 

--- a/configs/xen-arm64.config
+++ b/configs/xen-arm64.config
@@ -43,6 +43,7 @@ CONFIG_PVH_GUEST=y
 CONFIG_PV_SHIM=y
 # CONFIG_PV_SHIM_EXCLUSIVE is not set
 CONFIG_HYPERV_GUEST=y
+CONFIG_KVM_GUEST=y
 # CONFIG_REQUIRE_NX is not set
 # end of Architecture Features
 


### PR DESCRIPTION
Xen gained a KVM pvclock platform timer, so that a Xen running nested under KVM takes its time from the L0 hypervisor instead of calibrating against a timer the L0 VMM emulates. CONFIG_KVM_GUEST is default n, so without this the driver ships in the image and never runs.

Guarded like MEM_SHARING, because this one fails quietly: a dropped KVM_GUEST leaves Xen calibrating against emulated hardware exactly as before, with nothing in any log to say the driver was configured out. The guard catches the case that matters in practice -- building against a Xen branch that predates the driver, where olddefconfig discards the symbol because Kconfig has never heard of it.

Set in both configs, matching how the other x86-only symbols here are carried; arm64's olddefconfig drops it as it already does HYPERV_GUEST.